### PR TITLE
fix: attach MenuItem action to WorkflowRun instead of Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+	<repository>
+		<id>jenkins-releases</id>
+		<name>Jenkins Releases</name>
+		<url>http://repo.jenkins-ci.org/releases</url>
+	</repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -43,4 +48,11 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/io/jenkins/plugins/jenkinstl/MenuItem.java
+++ b/src/main/java/io/jenkins/plugins/jenkinstl/MenuItem.java
@@ -3,7 +3,11 @@ package io.jenkins.plugins.jenkinstl;
 import hudson.model.Action;
 
 public class MenuItem implements Action {
-    public MenuItem() {}
+    private String buildUrl;
+
+    public MenuItem(String buildUrl) {
+        this.buildUrl = buildUrl;
+    }
 
     @Override
     public String getIconFileName() {
@@ -17,6 +21,6 @@ public class MenuItem implements Action {
 
     @Override
     public String getUrlName() {
-        return "/plugin/jenkins-timeline/index.html";
+        return "/plugin/jenkins-timeline/index.html?build_url="+this.buildUrl;
     }
 }

--- a/src/main/java/io/jenkins/plugins/jenkinstl/MenuItemFactory.java
+++ b/src/main/java/io/jenkins/plugins/jenkinstl/MenuItemFactory.java
@@ -1,21 +1,22 @@
 package io.jenkins.plugins.jenkinstl;
 
-import jenkins.model.TransientActionFactory;
+import hudson.Extension;
 import hudson.model.Action;
 import java.util.Collection;
 import java.util.Collections;
-import hudson.Extension;
-import hudson.model.Build;
+import jenkins.model.TransientActionFactory;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 @Extension
-public class MenuItemFactory extends TransientActionFactory<Build> {
+public class MenuItemFactory extends TransientActionFactory<WorkflowRun> {
     @Override
-    public Class<Build> type() {
-        return Build.class; 
+    public Class<WorkflowRun> type() {
+        return WorkflowRun.class; 
     }
 
     @Override
-    public Collection<? extends Action> createFor(Build build) {
-        return Collections.singleton(new MenuItem()); 
+    public Collection<? extends Action> createFor(WorkflowRun build) {
+        String buildUrl = build.getAbsoluteUrl();
+        return Collections.singleton(new MenuItem(buildUrl)); 
     }
 }


### PR DESCRIPTION
## Description
Fixes the attachment of the menu link so that it appears on pipeline jobs (using `WorkflowRun`) instead of normal arbitrary jobs which do not have the `wfapi` endpoint.

## DevQA
### DevQA Prep
### DevQA Steps
### Comments:

