### PR TITLE
Call build_webapp within maven

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,27 +1,6 @@
 #!groovy
 
-node() {
-    stage('Setup') {
-        deleteDir()
-        checkout scm
-    }
-
-    docker.image('maven:3.6.0-jdk-8-alpine').inside {
-        try {
-            buildPlugin(
-                platforms: ['linux'],
-                tests: [skip: true]
-            )
-        } catch(err) {
-            currentBuild.result = "FAILURE"
-
-            if (err.toString().contains('exit code 143')) {
-                currentBuild.result = "ABORTED"
-            }
-        } finally {
-            stage('Cleanup') {
-                deleteDir()
-            }
-        }
-    }
-}
+buildPlugin(
+    platforms: ['linux'],
+    tests: [skip: true]
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,11 +8,6 @@ node() {
 
     docker.image('maven:3.6.0-jdk-8-alpine').inside {
         try {
-            stage('Building Everything') {
-                sh 'apk add make npm'
-                sh 'make build_all'
-            }
-
             buildPlugin(
                 platforms: ['linux'],
                 tests: [skip: true]

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,30 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>pipeline-timeline</artifactId>
-    <version>1.0</version>
+    <version>1.0.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
         <java.level>7</java.level>
     </properties>
+    <build><plugins><plugin>
+        <artifactId>exec-maven-plugin</artifactId>
+    <version>1.6.0</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+            <execution>
+                <id>Building webapp component</id>
+                <phase>compile</phase>
+                <goals>
+                    <goal>exec</goal>
+                </goals>
+                <configuration>
+                    <executable>make</executable>
+            <commandlineArgs>build_webapp</commandlineArgs>
+                </configuration>
+            </execution>
+        </executions>
+    </plugin></plugins></build>
     <name>Pipeline timeline</name>
     <description>An interactive build timeline to help you visualize your build pipeline and identify bottlenecks.</description>
     <licenses>


### PR DESCRIPTION
## Description
Tacking the `build_webapp` make recipe to the `compile` step of Maven to have it build on `ci.jenkins.io`. This is a follow-up from #49.