### PR TITLE
Install npm in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,15 @@
 #!groovy
 
-buildPlugin(
-    platforms: ['linux'],
-    tests: [skip: true]
-)
+node {
+    stage("Install dependencies") {
+        sh 'apt-get install nodejs -y'
+    }
+
+    stage("Build plugin") {
+        buildPlugin(
+            platforms: ['linux'],
+            tests: [skip: true]
+        )
+    }
+}
+


### PR DESCRIPTION
## Description
Assuming ci.jenkins.io uses jenkins/jenkins:lts, this should be the right way to install `npm` before the Maven build proceeds. This should let the publish process through `ci.jenkins.io` go through properly. 🤞 