### PR TITLE
ci: faster builds with maven cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,15 @@ jobs:
     steps:
       - checkout
       - run: apk add make npm
+      - restore_cache:
+          name: Restore node_modules cache
+          key: website-{{ checksum "pom.xml" }}-{{ .Branch }}
       - run: make build_all
+      - save_cache:
+          name: Save node_modules cache
+          key: website-{{ checksum "pom.xml" }}-{{ .Branch }}
+          paths:
+            - ~/.m2
       - run: make test
       - run: mkdir -p /tmp/artifacts
       - run: mkdir -p /tmp/versioning

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ jobs:
       - checkout
       - run: apk add make npm
       - restore_cache:
-          name: Restore node_modules cache
+          name: Restore maven cache
           key: website-{{ checksum "pom.xml" }}-{{ .Branch }}
       - run: make build_all
       - save_cache:
-          name: Save node_modules cache
+          name: Save maven cache
           key: website-{{ checksum "pom.xml" }}-{{ .Branch }}
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,11 @@ workflows:
       jobs:
           - lint_webapp
           - test_webapp
-          - test:
+          - test
+          - publish-github-release:
               requires:
                   - lint_webapp
                   - test_webapp
-          - publish-github-release:
-              requires:
                   - test
               filters:
                 branches:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build_all:
 
 .PHONY: build
 build:
-	mvn install -e
+	mvn install -e dependency:resolve-plugins dependency:go-offline
 
 .PHONY: build_webapp
 build_webapp:


### PR DESCRIPTION
## Description
Addresses #18 

Run's tests earlier, also caches deps


Before (run tests earlier):
<img width="480" alt="screen shot 2018-12-08 at 2 37 54 pm" src="https://user-images.githubusercontent.com/3534236/49689944-e2df8b80-faf6-11e8-8f13-b0a2edfe190c.png">

After (run tests earlier):
<img width="316" alt="screen shot 2018-12-08 at 2 37 47 pm" src="https://user-images.githubusercontent.com/3534236/49689946-e83cd600-faf6-11e8-8059-df02d02a936d.png">


Before (maven cache):
<img width="235" alt="screen shot 2018-12-08 at 2 40 41 pm" src="https://user-images.githubusercontent.com/3534236/49689969-584b5c00-faf7-11e8-9956-54aa60ad787d.png">

After (maven cache):
<img width="218" alt="screen shot 2018-12-08 at 2 43 30 pm" src="https://user-images.githubusercontent.com/3534236/49689989-af513100-faf7-11e8-8212-64c8905575e0.png">

Overall nearly 4 minutes faster!


## DevQA

### DevQA Steps
- Ci passes
- Run's again runs faster