### PR TITLE
Adding Docker development tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,19 @@ stop_jenkins::
 .PHONY: clean_jenkins
 clean_jenkins:
 	sh devResources/manageJenkins.sh clean
+
+.PHONY: start_env
+start_env:
+	sh devResources/manageBuildEnvironment.sh start
+
+.PHONY: stop_env
+stop_env::
+	sh devResources/manageBuildEnvironment.sh stop
+
+.PHONY: clean_env
+clean_env:
+	sh devResources/manageBuildEnvironment.sh clean
+
+.PHONY: exec_env
+exec_env:
+	sh devResources/manageBuildEnvironment.sh exec

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,7 @@ clean_env:
 .PHONY: exec_env
 exec_env:
 	sh devResources/manageBuildEnvironment.sh exec
+
+.PHONY: build_and_export
+build_and_export:
+	sh devResources/manageBuildEnvironment.sh build_plugin

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,15 @@ lint_webapp:
 .PHONY: lintfix_webapp
 lintfix_webapp:
 	cd $(WEBAPP_ROOT) && npm install && npm run lint-fix
+
+.PHONY: start_jenkins
+start_jenkins:
+	sh devResources/manageJenkins.sh start
+
+.PHONY: stop_jenkins
+stop_jenkins::
+	sh devResources/manageJenkins.sh stop
+
+.PHONY: clean_jenkins
+clean_jenkins:
+	sh devResources/manageJenkins.sh clean

--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ To work on the project, you will need ...
 - [A local instance of Jenkins](https://jenkins.io/doc/book/installing/);
 - [npm](https://www.npmjs.com/get-npm);
 
+__You can either install all of these on your machine, or use the Docker-based shortcuts included in the `Makefile`.__
+
+### Docker-based development environment
+
+You can leverage the power of Docker to avoid having to set up the development environment on your machine:
+
+Any of the following can be used by typing `make <cmd>` given you have Docker installed:
+
+| Command | Definition |
+|:---|:---|
+|`start_jenkins`|Starts a Jenkins docker machine bound to port 8080. Terminates any previous instance of itself.|
+|`stop_jenkins`|Stops a running instance of the Jenkins docker machine.|
+|`clean_jenkins`|Removes an existing instance of the Jenkins docker machine.|
+|`start_env`|Starts a docker machine set up with a copy of the local plugin files and Maven.|
+|`stop_env`|Stops a runnign instance of the build environment docker machine.|
+|`clean_env`|Removes an existing instance of the build environment.|
+|`exec_env`|Gives you console access to the build environment docker machine.|
+|`build_and_export`|Builds the plugin package from the local files in the build environment and exports the `hpi` artifact to your local work directory.|
+
 ### Compatibility note
 The linked version of Java (JDK 8) is the preferred version for this project, as Maven seems to have trouble building with other versions.
 

--- a/devResources/manageBuildEnvironment.sh
+++ b/devResources/manageBuildEnvironment.sh
@@ -1,0 +1,66 @@
+#!~/bin/sh
+
+ENV_CONTAINER=pipeline_timeline_build_env
+DOES_CONTAINER_ALREADY_EXIST=`docker ps -aq -f name=$ENV_CONTAINER`
+IS_CONTAINER_RUNNING=`docker ps -aq -f status=running -f name=$ENV_CONTAINER`
+IMAGE=maven:3.6.0-jdk-8
+
+start_env () {
+    echo "Starting fresh $ENV_CONTAINER"
+    docker run --dns 8.8.8.8 --name $ENV_CONTAINER --detach -it $IMAGE /bin/bash
+    echo "Copying files to $ENV_CONTAINER:/home"
+    docker cp ./ $ENV_CONTAINER:/home
+    echo "Use 'make exec_env' to enter the build environment."
+    return
+}
+
+stop_env () {
+    echo "Stopping $ENV_CONTAINER"
+    docker stop $ENV_CONTAINER
+    return
+}
+
+clean_env () {
+    echo "Removing $ENV_CONTAINER"
+    docker rm $ENV_CONTAINER
+    return
+}
+
+exec_env () {
+    docker exec -it $ENV_CONTAINER /bin/bash
+    return
+}
+
+if [[ $1 = "start" ]]; then
+    if [[ -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
+        echo "Container $ENV_CONTAINER is already exists!"
+        if [[ -n $IS_CONTAINER_RUNNING ]]; then
+            stop_env
+        fi
+        clean_env
+    fi
+    start_env
+elif [[ $1 = "stop" ]]; then
+    if [[ ! -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
+        echo "Container $ENV_CONTAINER does not exist."
+    elif [[ ! -n $IS_CONTAINER_RUNNING ]]; then
+        echo "Container $ENV_CONTAINER is not running."
+    else
+        stop_env
+    fi
+elif [[ $1 = "clean" ]]; then
+    if [[ ! -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
+        echo "Container $ENV_CONTAINER does not exist."
+    else
+        if [[ -n $IS_CONTAINER_RUNNING ]]; then
+            stop_env
+        fi
+        clean_env
+    fi
+elif [[ $1 = "exec" ]]; then
+    if [[ -n $IS_CONTAINER_RUNNING ]]; then
+        exec_env
+    fi
+fi
+
+echo "All done!"

--- a/devResources/manageBuildEnvironment.sh
+++ b/devResources/manageBuildEnvironment.sh
@@ -31,6 +31,12 @@ exec_env () {
     return
 }
 
+build_and_export_hpi () {
+    docker exec -ti $ENV_CONTAINER sh -c "cd /home && mvn install"
+    docker cp $ENV_CONTAINER:/home/target/pipeline-timeline.hpi .
+    return
+}
+
 if [[ $1 = "start" ]]; then
     if [[ -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
         echo "Container $ENV_CONTAINER is already exists!"
@@ -60,7 +66,16 @@ elif [[ $1 = "clean" ]]; then
 elif [[ $1 = "exec" ]]; then
     if [[ -n $IS_CONTAINER_RUNNING ]]; then
         exec_env
+    else
+        echo "Build environment container is not running."
+    fi
+elif [[ $1 = "build_plugin" ]]; then
+    if [[ -n $IS_CONTAINER_RUNNING ]]; then
+        echo "Building the hpi package in $ENV_CONTAINER and exporting it to the host."
+        build_and_export_hpi
+        HPI_LOC=`pwd`
+        echo "All done! The hpi package has been copied to $HPI_LOC"
+    else
+        echo "Build environment container is not running."
     fi
 fi
-
-echo "All done!"

--- a/devResources/manageJenkins.sh
+++ b/devResources/manageJenkins.sh
@@ -3,10 +3,11 @@
 JENKINS_CONTAINER=local_jenkins
 DOES_CONTAINER_ALREADY_EXIST=`docker ps -aq -f name=$JENKINS_CONTAINER`
 IS_CONTAINER_RUNNING=`docker ps -aq -f status=running -f name=$JENKINS_CONTAINER`
+IMAGE=jenkinsci/blueocean
 
 start_jenkins () {
     echo "Starting fresh $JENKINS_CONTAINER"
-    docker run -p 8080:8080 -p 50000:50000 --name $JENKINS_CONTAINER --detach jenkinsci/blueocean
+    docker run -p 8080:8080 -p 50000:50000 --name $JENKINS_CONTAINER --detach $IMAGE
     echo "Jenkins machine available at http://locahost:/8080"
     return
 }

--- a/devResources/manageJenkins.sh
+++ b/devResources/manageJenkins.sh
@@ -1,0 +1,52 @@
+#!~/bin/sh
+
+JENKINS_CONTAINER=local_jenkins
+DOES_CONTAINER_ALREADY_EXIST=`docker ps -aq -f name=$JENKINS_CONTAINER`
+IS_CONTAINER_RUNNING=`docker ps -aq -f status=running -f name=$JENKINS_CONTAINER`
+
+start_jenkins () {
+    echo "Starting fresh $JENKINS_CONTAINER"
+    docker run -p 8080:8080 -p 50000:50000 --name $JENKINS_CONTAINER --detach jenkinsci/blueocean
+    echo "Jenkins machine available at http://locahost:/8080"
+    return
+}
+
+stop_jenkins () {
+    echo "Stopping $JENKINS_CONTAINER"
+    docker stop $JENKINS_CONTAINER > /dev/null
+    return
+}
+
+clean_jenkins () {
+    echo "Removing $JENKINS_CONTAINER"
+    docker rm $JENKINS_CONTAINER > /dev/null
+    return
+}
+
+if [[ $1 = "start" ]]; then
+    if [[ -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
+        echo "Container $JENKINS_CONTAINER is already exists!"
+        if [[ -n $IS_CONTAINER_RUNNING ]]; then
+            stop_jenkins
+        fi
+        clean_jenkins
+    fi
+    start_jenkins
+elif [[ $1 = "stop" ]]; then
+    if [[ ! -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
+        echo "Container $JENKINS_CONTAINER does not exist."
+    elif [[ ! -n $IS_CONTAINER_RUNNING ]]; then
+        echo "Container $JENKINS_CONTAINER is not running."
+    else
+        stop_jenkins
+    fi
+elif [[ $1 = "clean" ]]; then
+    if [[ ! -n $DOES_CONTAINER_ALREADY_EXIST ]]; then
+        echo "Container $JENKINS_CONTAINER does not exist."
+    else
+        if [[ -n $IS_CONTAINER_RUNNING ]]; then
+            stop_jenkins
+        fi
+        clean_jenkins
+    fi
+fi


### PR DESCRIPTION
## Description
This PR adds a handful of `make` commands to handle Docker machines that run a local Jenkins instance and a build environment ready to build the Maven project.

This tooling aims to make it easier for contributors to get started by skipping a lot of the setup steps and jumping right into being able to run and build the plugin.

## DevQA

### DevQA Prep
Have `Docker`.

### DevQA Steps
Run the new `make` commands and check that a Docker container gets spawned on `start_*`, stopped on `stop_*` and removed on `clean_*`. Additionally, `exec_env` will `exec` into the build environment docker machine.

You can also use the `build_and_export` command to build the plugin package within the build env. container and export it to your pwd once it's done.

🚀Less setup before contributing! 🚀 

### Comments: