### PR TITLE
fix getUrlName() when jenkins url is not in "/"

### DIFF
--- a/src/main/java/io/jenkins/plugins/jenkinstl/MenuItem.java
+++ b/src/main/java/io/jenkins/plugins/jenkinstl/MenuItem.java
@@ -21,6 +21,6 @@ public class MenuItem implements Action {
 
     @Override
     public String getUrlName() {
-        return "/plugin/pipeline-timeline/index.html?build_url="+this.buildUrl;
+        return "plugin/pipeline-timeline/index.html?build_url="+this.buildUrl;
     }
 }

--- a/src/test/java/io/jenkins/plugins/jenkinstl/MenuItemTest.java
+++ b/src/test/java/io/jenkins/plugins/jenkinstl/MenuItemTest.java
@@ -9,7 +9,7 @@ public class MenuItemTest {
         String mockUrl = "http://jenkinsbox.com/job/1";
         MenuItem item = new MenuItem(mockUrl);
         String composedUrl = item.getUrlName();
-        String expected = "/plugin/pipeline-timeline/index.html?build_url="+mockUrl;
+        String expected = "plugin/pipeline-timeline/index.html?build_url="+mockUrl;
         Assert.assertEquals(composedUrl, expected);
     }
 }


### PR DESCRIPTION
## Description

* `getUrlName()` method is changed to return a relative path instead of an absolute one

## DevQA

### DevQA Prep

### DevQA Steps

Check that it fixes the plugin when running with a Jenkins URL such as `http://hostname/jenkins/` instead of `http://hostname/`

### Comments:


