### PR TITLE
fix: Display correct build time duration for builds longer than an hour

### DIFF
--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -38,7 +38,7 @@ export default class DashHeader extends React.PureComponent {
     formatTime = timestamp => {
         const seconds = parseInt(timestamp / 1000) % 60
         const minutes = parseInt(timestamp / (1000 * 60)) % 60
-        const hours = parseInt(timestamp / (1000 * 3600)) % 60
+        const hours = parseInt(timestamp / (1000 * 3600))
 
         const parts = []
 

--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -38,8 +38,14 @@ export default class DashHeader extends React.PureComponent {
     formatTime = timestamp => {
         const seconds = parseInt(timestamp / 1000) % 60
         const minutes = parseInt(timestamp / (1000 * 60)) % 60
+        const hours = parseInt(timestamp / (1000 * 3600)) % 60
 
         const parts = []
+
+        if (hours >= 1) {
+            const plural = hours > 1 ? 's' : ''
+            parts.push(`${hours} hours${plural}`)
+        }
 
         if (minutes >= 1) {
             const plural = minutes > 1 ? `s` : ``

--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -44,7 +44,7 @@ export default class DashHeader extends React.PureComponent {
 
         if (hours >= 1) {
             const plural = hours > 1 ? 's' : ''
-            parts.push(`${hours} hours${plural}`)
+            parts.push(`${hours} hour${plural}`)
         }
 
         if (minutes >= 1) {


### PR DESCRIPTION
## Description
Show the hours, as well as the minutes/seconds, for builds that take longer than an hour