### PR TITLE
#116/feat build navigation button

### DIFF
--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -77,14 +77,16 @@ export default class DashHeader extends React.PureComponent {
                     <img alt="Build timeline" src={Logo} />
                     <Title>{`Build timeline > ${this.props.buildName}`}</Title>
                 </LogoBox>
-                {this.getBuildNavButton(prevBuildId, 'Previous Build')}
-                {this.getBuildNavButton(nextBuildId, 'Next Build')}
-                <BackButton
-                    onClick={this.onBackButtonClick}
-                    href={this.props.buildUrl}
-                >
-                    Back to Jenkins
-                </BackButton>
+                <div>
+                    {this.getBuildNavButton(prevBuildId, 'Previous Build')}
+                    {this.getBuildNavButton(nextBuildId, 'Next Build')}
+                    <BackButton
+                        onClick={this.onBackButtonClick}
+                        href={this.props.buildUrl}
+                    >
+                        Back to Jenkins
+                    </BackButton>
+                </div>
             </TopBar>
         )
     }

--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -10,6 +10,7 @@ import {
     Title,
     LogoBox,
     BackButton,
+    BuildNavigationBar
 } from './DashHeader.style'
 import { statusMap, buildStatuses } from '../constants'
 import Logo from '../assets/logo.png'
@@ -147,29 +148,34 @@ export default class DashHeader extends React.PureComponent {
         window.location.assign(buildUrl)
     }
 
+    getBuildNavButton = (baseUrl, buildId, displayText) => {
+        if (buildId < 1) return null
+
+        const buildUrl = baseUrl + `/${buildId}/`
+
+        return (
+            <BackButton
+                onClick={this.onBuildNavButtonClick(buildUrl)}
+                href={buildUrl}
+            >
+                {displayText}
+            </BackButton>
+        )
+    }
+
     getBuildNavigateBar = () => {
-        const prevBuildId = parseInt(this.props.buildId) - 1
-        const nextBuildId = parseInt(this.props.buildId) + 1
+        const currBuildId = parseInt(this.props.buildId)
+        const prevBuildId = currBuildId - 1
+        const nextBuildId = currBuildId + 1
 
-        const buildUrlNoId = window.location.href.split('/').slice(0, -1).join('/')
-
-        const prevBuildUrl = buildUrlNoId + `/${prevBuildId}/`
-        const nextBuildUrl = buildUrlNoId + `/${nextBuildId}/`
+        const buildUrlNoId = window.location.href.split('/').slice(0, -2).join('/')
 
         return (
             <React.Fragment>
-                <BackButton
-                    onClick={this.onBuildNavButtonClick(prevBuildUrl)}
-                    href={prevBuildUrl}
-                >
-                    Previous Build
-                </BackButton> 
-                <BackButton
-                    onClick={this.onBuildNavButtonClick(nextBuildUrl)}
-                    href={nextBuildUrl}
-                >
-                    Next Build
-                </BackButton>
+                <BuildNavigationBar>
+                    {this.getBuildNavButton(buildUrlNoId, prevBuildId, "Previous Build")}
+                    {this.getBuildNavButton(buildUrlNoId, nextBuildId, "Next Build")}
+                </BuildNavigationBar>
             </React.Fragment>
         )
     }

--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -10,7 +10,7 @@ import {
     Title,
     LogoBox,
     BackButton,
-    BuildNavigationBar
+    BuildNavigationBar,
 } from './DashHeader.style'
 import { statusMap, buildStatuses } from '../constants'
 import Logo from '../assets/logo.png'
@@ -151,7 +151,7 @@ export default class DashHeader extends React.PureComponent {
     getBuildNavButton = (baseUrl, buildId, displayText) => {
         if (buildId < 1) return null
 
-        const buildUrl = baseUrl + `/${buildId}/`
+        const buildUrl = `${baseUrl}/${buildId}/`
 
         return (
             <BackButton
@@ -168,13 +168,24 @@ export default class DashHeader extends React.PureComponent {
         const prevBuildId = currBuildId - 1
         const nextBuildId = currBuildId + 1
 
-        const buildUrlNoId = window.location.href.split('/').slice(0, -2).join('/')
+        const buildUrlNoId = window.location.href
+            .split('/')
+            .slice(0, -2)
+            .join('/')
 
         return (
             <React.Fragment>
                 <BuildNavigationBar>
-                    {this.getBuildNavButton(buildUrlNoId, prevBuildId, "Previous Build")}
-                    {this.getBuildNavButton(buildUrlNoId, nextBuildId, "Next Build")}
+                    {this.getBuildNavButton(
+                        buildUrlNoId,
+                        prevBuildId,
+                        'Previous Build',
+                    )}
+                    {this.getBuildNavButton(
+                        buildUrlNoId,
+                        nextBuildId,
+                        'Next Build',
+                    )}
                 </BuildNavigationBar>
             </React.Fragment>
         )

--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -16,6 +16,7 @@ import Logo from '../assets/logo.png'
 
 export default class DashHeader extends React.PureComponent {
     static propTypes = {
+        buildId: PropTypes.string.isRequired,
         buildStatus: PropTypes.string,
         buildUrl: PropTypes.string.isRequired,
         buildName: PropTypes.string.isRequired,
@@ -142,10 +143,42 @@ export default class DashHeader extends React.PureComponent {
         )
     }
 
+    onBuildNavButtonClick = buildUrl => () => {
+        window.location.assign(buildUrl)
+    }
+
+    getBuildNavigateBar = () => {
+        const prevBuildId = parseInt(this.props.buildId) - 1
+        const nextBuildId = parseInt(this.props.buildId) + 1
+
+        const buildUrlNoId = window.location.href.split('/').slice(0, -1).join('/')
+
+        const prevBuildUrl = buildUrlNoId + `/${prevBuildId}/`
+        const nextBuildUrl = buildUrlNoId + `/${nextBuildId}/`
+
+        return (
+            <React.Fragment>
+                <BackButton
+                    onClick={this.onBuildNavButtonClick(prevBuildUrl)}
+                    href={prevBuildUrl}
+                >
+                    Previous Build
+                </BackButton> 
+                <BackButton
+                    onClick={this.onBuildNavButtonClick(nextBuildUrl)}
+                    href={nextBuildUrl}
+                >
+                    Next Build
+                </BackButton>
+            </React.Fragment>
+        )
+    }
+
     render() {
         return (
             <Container status={this.props.buildStatus}>
                 {this.getTopBar()}
+                {this.getBuildNavigateBar()}
                 {this.getDetailsBar()}
             </Container>
         )

--- a/webapp_src/src/components/DashHeader.js
+++ b/webapp_src/src/components/DashHeader.js
@@ -10,7 +10,6 @@ import {
     Title,
     LogoBox,
     BackButton,
-    BuildNavigationBar,
 } from './DashHeader.style'
 import { statusMap, buildStatuses } from '../constants'
 import Logo from '../assets/logo.png'
@@ -28,6 +27,8 @@ export default class DashHeader extends React.PureComponent {
             duration: PropTypes.number,
         }).isRequired,
         startTime: PropTypes.instanceOf(moment),
+        onClickBuildNavButton: PropTypes.func.isRequired,
+        runCount: PropTypes.number.isRequired,
     }
 
     static defaultProps = {
@@ -66,20 +67,27 @@ export default class DashHeader extends React.PureComponent {
         window.location.assign(this.props.buildUrl)
     }
 
-    getTopBar = () => (
-        <TopBar>
-            <LogoBox>
-                <img alt="Build timeline" src={Logo} />
-                <Title>{`Build timeline > ${this.props.buildName}`}</Title>
-            </LogoBox>
-            <BackButton
-                onClick={this.onBackButtonClick}
-                href={this.props.buildUrl}
-            >
-                Back to Jenkins
-            </BackButton>
-        </TopBar>
-    )
+    getTopBar = () => {
+        const currBuildId = parseInt(this.props.buildId)
+        const prevBuildId = currBuildId - 1
+        const nextBuildId = currBuildId + 1
+        return (
+            <TopBar>
+                <LogoBox>
+                    <img alt="Build timeline" src={Logo} />
+                    <Title>{`Build timeline > ${this.props.buildName}`}</Title>
+                </LogoBox>
+                {this.getBuildNavButton(prevBuildId, 'Previous Build')}
+                {this.getBuildNavButton(nextBuildId, 'Next Build')}
+                <BackButton
+                    onClick={this.onBackButtonClick}
+                    href={this.props.buildUrl}
+                >
+                    Back to Jenkins
+                </BackButton>
+            </TopBar>
+        )
+    }
 
     getLongestStageLabel = () => {
         if (!this.props.longestStage) return null
@@ -144,50 +152,13 @@ export default class DashHeader extends React.PureComponent {
         )
     }
 
-    onBuildNavButtonClick = buildUrl => () => {
-        window.location.assign(buildUrl)
-    }
-
-    getBuildNavButton = (baseUrl, buildId, displayText) => {
-        if (buildId < 1) return null
-
-        const buildUrl = `${baseUrl}/${buildId}/`
+    getBuildNavButton = (buildId, displayText) => {
+        if (buildId < 1 || buildId > this.props.runCount) return null
 
         return (
-            <BackButton
-                onClick={this.onBuildNavButtonClick(buildUrl)}
-                href={buildUrl}
-            >
+            <BackButton onClick={this.props.onClickBuildNavButton(buildId)}>
                 {displayText}
             </BackButton>
-        )
-    }
-
-    getBuildNavigateBar = () => {
-        const currBuildId = parseInt(this.props.buildId)
-        const prevBuildId = currBuildId - 1
-        const nextBuildId = currBuildId + 1
-
-        const buildUrlNoId = window.location.href
-            .split('/')
-            .slice(0, -2)
-            .join('/')
-
-        return (
-            <React.Fragment>
-                <BuildNavigationBar>
-                    {this.getBuildNavButton(
-                        buildUrlNoId,
-                        prevBuildId,
-                        'Previous Build',
-                    )}
-                    {this.getBuildNavButton(
-                        buildUrlNoId,
-                        nextBuildId,
-                        'Next Build',
-                    )}
-                </BuildNavigationBar>
-            </React.Fragment>
         )
     }
 
@@ -195,7 +166,6 @@ export default class DashHeader extends React.PureComponent {
         return (
             <Container status={this.props.buildStatus}>
                 {this.getTopBar()}
-                {this.getBuildNavigateBar()}
                 {this.getDetailsBar()}
             </Container>
         )

--- a/webapp_src/src/components/DashHeader.style.js
+++ b/webapp_src/src/components/DashHeader.style.js
@@ -72,3 +72,10 @@ export const BackButton = styled.button`
         border-color: transparent;
     }
 `
+
+export const BuildNavigationBar = styled.div`
+    background-color:rgba(0, 0, 0, 0.2);
+    display: flex;
+    justify-content: flex-start;
+    padding: 10px;
+`

--- a/webapp_src/src/components/DashHeader.style.js
+++ b/webapp_src/src/components/DashHeader.style.js
@@ -42,7 +42,7 @@ export const Label = styled.span`
 `
 
 export const TopBar = styled.div`
-    background-color:rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.2);
     padding: 10px;
     display: flex;
     align-items: center;
@@ -61,21 +61,14 @@ export const LogoBox = styled.div`
 
 export const BackButton = styled.button`
     padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
+    border: 3px solid rgba(0, 0, 0, 0.3);
     background-color: transparent;
     cursor: pointer;
     transition: 0.5s;
     color: ${Colours.TEXT};
 
     &:hover {
-        background-color: rgba(0,0,0,0.3);
+        background-color: rgba(0, 0, 0, 0.3);
         border-color: transparent;
     }
-`
-
-export const BuildNavigationBar = styled.div`
-    background-color:rgba(0, 0, 0, 0.2);
-    display: flex;
-    justify-content: flex-start;
-    padding: 10px;
 `

--- a/webapp_src/src/components/Dashboard.js
+++ b/webapp_src/src/components/Dashboard.js
@@ -25,8 +25,15 @@ export default class Dashboard extends React.Component {
         return `${url}wfapi/describe`
     }
 
-    componentDidMount() {
-        const buildEndpoint = this.buildApiURL(this.props.buildUrl)
+    // endpoint for /job/<jobName>/
+    jobApiURL = () => {
+        return this.props.buildUrl
+            .split('/')
+            .slice(0, -2)
+            .join('/')
+    }
+
+    fetchBuildData = buildEndpoint => {
         axios.get(buildEndpoint).then(result => {
             const stages = result.data.stages
             const promises = stages.map(stage => {
@@ -50,6 +57,23 @@ export default class Dashboard extends React.Component {
                 })
             })
         })
+    }
+
+    componentDidMount() {
+        const buildEndpoint = this.buildApiURL(this.props.buildUrl)
+        axios.get(`${this.jobApiURL()}/wfapi/`).then(result => {
+            this.setState({
+                runCount: result.data.runCount,
+            })
+        })
+        this.fetchBuildData(buildEndpoint)
+    }
+
+    onClickBuildNavButton = buildId => () => {
+        const newBuildEndpoint = this.buildApiURL(
+            `${this.jobApiURL()}/${buildId}/`,
+        )
+        this.fetchBuildData(newBuildEndpoint)
     }
 
     getStageInfo = stageEndpoint => {
@@ -130,6 +154,8 @@ export default class Dashboard extends React.Component {
                     buildName={this.state.title}
                     longestStage={this.state.longestStage}
                     endTime={endTime}
+                    onClickBuildNavButton={this.onClickBuildNavButton}
+                    runCount={this.state.runCount}
                 />
                 <DashContainer>
                     <Chart

--- a/webapp_src/src/components/Dashboard.js
+++ b/webapp_src/src/components/Dashboard.js
@@ -36,6 +36,7 @@ export default class Dashboard extends React.Component {
             Promise.all(promises).then(stages => {
                 const longestStage = this.findLongestStage(stages)
                 this.setState({
+                    buildId: result.data.id,
                     title: result.data.name,
                     longestStage,
                     stages,
@@ -121,6 +122,7 @@ export default class Dashboard extends React.Component {
         return (
             <React.Fragment>
                 <DashHeader
+                    buildId={this.state.buildId}
                     buildStatus={this.state.status}
                     startTime={this.state.start}
                     duration={this.state.duration}

--- a/webapp_src/src/components/test/DashHeader.test.js
+++ b/webapp_src/src/components/test/DashHeader.test.js
@@ -17,6 +17,8 @@ describe('DashHeader', () => {
             title: 'Preparation',
             duration: 15131,
         },
+        onClickBuildNavButton: () => {},
+        runCount: 6,
     }
     it('renders the component', () => {
         const requiredProps = {
@@ -27,6 +29,8 @@ describe('DashHeader', () => {
                 title: 'Preparation',
                 duration: 15131,
             },
+            onClickBuildNavButton: () => {},
+            runCount: 6,
         }
 
         const header = shallow(<DashHeader {...requiredProps} />)

--- a/webapp_src/src/components/test/DashHeader.test.js
+++ b/webapp_src/src/components/test/DashHeader.test.js
@@ -19,7 +19,17 @@ describe('DashHeader', () => {
         },
     }
     it('renders the component', () => {
-        const header = shallow(<DashHeader {...defaultProps} />)
+        const requiredProps = {
+            buildId: '3',
+            buildUrl: 'http://localhost:8080/job/test-pipeline/3/',
+            buildName: '#3',
+            longestStage: {
+                title: 'Preparation',
+                duration: 15131,
+            },
+        }
+
+        const header = shallow(<DashHeader {...requiredProps} />)
         expect(header).toMatchSnapshot()
     })
 

--- a/webapp_src/src/components/test/DashHeader.test.js
+++ b/webapp_src/src/components/test/DashHeader.test.js
@@ -15,8 +15,8 @@ describe('DashHeader', () => {
         buildName: '#3',
         longestStage: {
             title: 'Preparation',
-            duration: 15131
-        }
+            duration: 15131,
+        },
     }
     it('renders the component', () => {
         const header = shallow(<DashHeader {...defaultProps} />)

--- a/webapp_src/src/components/test/DashHeader.test.js
+++ b/webapp_src/src/components/test/DashHeader.test.js
@@ -7,12 +7,19 @@ import { statusMap, buildStatuses } from '../../constants'
 
 describe('DashHeader', () => {
     const defaultProps = {
-        startTime: moment(),
-        endTime: moment(),
+        startTime: moment('2021-02-24T23:50:56.796Z'),
+        endTime: moment('2021-02-24T23:50:56.797Z'),
         duration: 1,
+        buildId: '3',
+        buildUrl: 'http://localhost:8080/job/test-pipeline/3/',
+        buildName: '#3',
+        longestStage: {
+            title: 'Preparation',
+            duration: 15131
+        }
     }
     it('renders the component', () => {
-        const header = shallow(<DashHeader />)
+        const header = shallow(<DashHeader {...defaultProps} />)
         expect(header).toMatchSnapshot()
     })
 
@@ -71,7 +78,7 @@ describe('DashHeader', () => {
             duration: 55000,
         }
         const header = shallow(
-            <DashHeader longestStage={longestStage} {...defaultProps} />,
+            <DashHeader {...defaultProps} longestStage={longestStage} />,
         )
         const label = header.find({ clickId: 'timeline longest stage' })
         expect(label.exists()).toEqual(true)

--- a/webapp_src/src/components/test/Dashboard.test.js
+++ b/webapp_src/src/components/test/Dashboard.test.js
@@ -5,7 +5,11 @@ import React from 'react'
 import moment from 'moment'
 
 import Dashboard from '../Dashboard'
-import { mockWfApiResponse, mockNodeApiResponse } from './mockData'
+import {
+    mockWfApiResponse,
+    mockNodeApiResponse,
+    mockJobWfApiResponse,
+} from './mockData'
 
 function flushPromises() {
     return new Promise(resolve => setImmediate(resolve))
@@ -49,6 +53,9 @@ describe('Dashboard', () => {
             const spy = jest
                 .spyOn(axios, 'get')
                 .mockImplementationOnce(() =>
+                    Promise.resolve(mockJobWfApiResponse),
+                )
+                .mockImplementationOnce(() =>
                     Promise.resolve(mockWfApiResponse),
                 )
                 .mockImplementationOnce(() =>
@@ -56,12 +63,15 @@ describe('Dashboard', () => {
                 )
             mount(<Dashboard buildUrl={mockBuildUrl} />)
             return flushPromises().then(() => {
-                expect(spy).toHaveBeenCalledTimes(2)
+                expect(spy).toHaveBeenCalledTimes(3)
             })
         })
 
         it('sets the state correctly from the api data', () => {
             jest.spyOn(axios, 'get')
+                .mockImplementationOnce(() =>
+                    Promise.resolve(mockJobWfApiResponse),
+                )
                 .mockImplementationOnce(() =>
                     Promise.resolve(mockWfApiResponse),
                 )

--- a/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
+++ b/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
@@ -43,6 +43,22 @@ ShallowWrapper {
         <React.Fragment>
           <ForwardRef>
             <ForwardRef
+              href="http://NaN/"
+              onClick={[Function]}
+            >
+              Previous Build
+            </ForwardRef>
+            <ForwardRef
+              href="http://NaN/"
+              onClick={[Function]}
+            >
+              Next Build
+            </ForwardRef>
+          </ForwardRef>
+        </React.Fragment>,
+        <React.Fragment>
+          <ForwardRef>
+            <ForwardRef
               clickId="timeline build status"
             >
               Status: N/A
@@ -233,6 +249,164 @@ ShallowWrapper {
           "warnTooManyClasses": [Function],
           "withComponent": [Function],
         },
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "children": <ForwardRef>
+            <ForwardRef
+              href="http://NaN/"
+              onClick={[Function]}
+            >
+              Previous Build
+            </ForwardRef>
+            <ForwardRef
+              href="http://NaN/"
+              onClick={[Function]}
+            >
+              Next Build
+            </ForwardRef>
+          </ForwardRef>,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": Array [
+              <ForwardRef
+                href="http://NaN/"
+                onClick={[Function]}
+              >
+                Previous Build
+              </ForwardRef>,
+              <ForwardRef
+                href="http://NaN/"
+                onClick={[Function]}
+              >
+                Next Build
+              </ForwardRef>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": "Previous Build",
+                "href": "http://NaN/",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Previous Build",
+              "type": Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-bZQynM",
+                  "isStatic": true,
+                  "rules": Array [
+                    "
+    padding: 10px;
+    border: 3px solid rgba(0,0,0,0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                    "#fff",
+                    ";
+
+    &:hover {
+        background-color: rgba(0,0,0,0.3);
+        border-color: transparent;
+    }
+",
+                  ],
+                },
+                "displayName": "styled.button",
+                "render": [Function],
+                "styledComponentId": "sc-bZQynM",
+                "target": "button",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              },
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": "Next Build",
+                "href": "http://NaN/",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": "Next Build",
+              "type": Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-bZQynM",
+                  "isStatic": true,
+                  "rules": Array [
+                    "
+    padding: 10px;
+    border: 3px solid rgba(0,0,0,0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                    "#fff",
+                    ";
+
+    &:hover {
+        background-color: rgba(0,0,0,0.3);
+        border-color: transparent;
+    }
+",
+                  ],
+                },
+                "displayName": "styled.button",
+                "render": [Function],
+                "styledComponentId": "sc-bZQynM",
+                "target": "button",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              },
+            },
+          ],
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "sc-gzVnrw",
+              "isStatic": true,
+              "rules": Array [
+                "
+    background-color:rgba(0, 0, 0, 0.2);
+    display: flex;
+    justify-content: flex-start;
+    padding: 10px;
+",
+              ],
+            },
+            "displayName": "styled.div",
+            "render": [Function],
+            "styledComponentId": "sc-gzVnrw",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          },
+        },
+        "type": Symbol(react.fragment),
       },
       Object {
         "instance": null,
@@ -481,6 +655,22 @@ ShallowWrapper {
           <React.Fragment>
             <ForwardRef>
               <ForwardRef
+                href="http://NaN/"
+                onClick={[Function]}
+              >
+                Previous Build
+              </ForwardRef>
+              <ForwardRef
+                href="http://NaN/"
+                onClick={[Function]}
+              >
+                Next Build
+              </ForwardRef>
+            </ForwardRef>
+          </React.Fragment>,
+          <React.Fragment>
+            <ForwardRef>
+              <ForwardRef
                 clickId="timeline build status"
               >
                 Status: N/A
@@ -671,6 +861,164 @@ ShallowWrapper {
             "warnTooManyClasses": [Function],
             "withComponent": [Function],
           },
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": <ForwardRef>
+              <ForwardRef
+                href="http://NaN/"
+                onClick={[Function]}
+              >
+                Previous Build
+              </ForwardRef>
+              <ForwardRef
+                href="http://NaN/"
+                onClick={[Function]}
+              >
+                Next Build
+              </ForwardRef>
+            </ForwardRef>,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <ForwardRef
+                  href="http://NaN/"
+                  onClick={[Function]}
+                >
+                  Previous Build
+                </ForwardRef>,
+                <ForwardRef
+                  href="http://NaN/"
+                  onClick={[Function]}
+                >
+                  Next Build
+                </ForwardRef>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Previous Build",
+                  "href": "http://NaN/",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Previous Build",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bZQynM",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    padding: 10px;
+    border: 3px solid rgba(0,0,0,0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                      "#fff",
+                      ";
+
+    &:hover {
+        background-color: rgba(0,0,0,0.3);
+        border-color: transparent;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.button",
+                  "render": [Function],
+                  "styledComponentId": "sc-bZQynM",
+                  "target": "button",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Next Build",
+                  "href": "http://NaN/",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Next Build",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bZQynM",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    padding: 10px;
+    border: 3px solid rgba(0,0,0,0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                      "#fff",
+                      ";
+
+    &:hover {
+        background-color: rgba(0,0,0,0.3);
+        border-color: transparent;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.button",
+                  "render": [Function],
+                  "styledComponentId": "sc-bZQynM",
+                  "target": "button",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
+            ],
+            "type": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "sc-gzVnrw",
+                "isStatic": true,
+                "rules": Array [
+                  "
+    background-color:rgba(0, 0, 0, 0.2);
+    display: flex;
+    justify-content: flex-start;
+    padding: 10px;
+",
+                ],
+              },
+              "displayName": "styled.div",
+              "render": [Function],
+              "styledComponentId": "sc-gzVnrw",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            },
+          },
+          "type": Symbol(react.fragment),
         },
         Object {
           "instance": null,

--- a/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
+++ b/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
@@ -16,6 +16,8 @@ ShallowWrapper {
         "title": "Preparation",
       }
     }
+    onClickBuildNavButton={[Function]}
+    runCount={6}
     startTime={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -43,29 +45,21 @@ ShallowWrapper {
               Build timeline &gt; #3
             </ForwardRef>
           </ForwardRef>
-          <ForwardRef
-            href="http://localhost:8080/job/test-pipeline/3/"
-            onClick={[Function]}
-          >
-            Back to Jenkins
-          </ForwardRef>
-        </ForwardRef>,
-        <React.Fragment>
-          <ForwardRef>
-            <ForwardRef
-              href="http://2/"
-              onClick={[Function]}
-            >
+          <div>
+            <ForwardRef>
               Previous Build
             </ForwardRef>
-            <ForwardRef
-              href="http://4/"
-              onClick={[Function]}
-            >
+            <ForwardRef>
               Next Build
             </ForwardRef>
-          </ForwardRef>
-        </React.Fragment>,
+            <ForwardRef
+              href="http://localhost:8080/job/test-pipeline/3/"
+              onClick={[Function]}
+            >
+              Back to Jenkins
+            </ForwardRef>
+          </div>
+        </ForwardRef>,
         <React.Fragment>
           <ForwardRef>
             <ForwardRef
@@ -103,12 +97,20 @@ ShallowWrapper {
                 Build timeline &gt; #3
               </ForwardRef>
             </ForwardRef>,
-            <ForwardRef
-              href="http://localhost:8080/job/test-pipeline/3/"
-              onClick={[Function]}
-            >
-              Back to Jenkins
-            </ForwardRef>,
+            <div>
+              <ForwardRef>
+                Previous Build
+              </ForwardRef>
+              <ForwardRef>
+                Next Build
+              </ForwardRef>
+              <ForwardRef
+                href="http://localhost:8080/job/test-pipeline/3/"
+                onClick={[Function]}
+              >
+                Back to Jenkins
+              </ForwardRef>
+            </div>,
           ],
         },
         "ref": null,
@@ -199,46 +201,157 @@ ShallowWrapper {
           Object {
             "instance": null,
             "key": undefined,
-            "nodeType": "function",
+            "nodeType": "host",
             "props": Object {
-              "children": "Back to Jenkins",
-              "href": "http://localhost:8080/job/test-pipeline/3/",
-              "onClick": [Function],
+              "children": Array [
+                <ForwardRef>
+                  Previous Build
+                </ForwardRef>,
+                <ForwardRef>
+                  Next Build
+                </ForwardRef>,
+                <ForwardRef
+                  href="http://localhost:8080/job/test-pipeline/3/"
+                  onClick={[Function]}
+                >
+                  Back to Jenkins
+                </ForwardRef>,
+              ],
             },
             "ref": null,
-            "rendered": "Back to Jenkins",
-            "type": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "attrs": Array [],
-              "componentStyle": ComponentStyle {
-                "componentId": "sc-bZQynM",
-                "isStatic": true,
-                "rules": Array [
-                  "
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Previous Build",
+                  "onClick": undefined,
+                },
+                "ref": null,
+                "rendered": "Previous Build",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bZQynM",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
     padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
+    border: 3px solid rgba(0, 0, 0, 0.3);
     background-color: transparent;
     cursor: pointer;
     transition: 0.5s;
     color: ",
-                  "#fff",
-                  ";
+                      "#fff",
+                      ";
 
     &:hover {
-        background-color: rgba(0,0,0,0.3);
+        background-color: rgba(0, 0, 0, 0.3);
         border-color: transparent;
     }
 ",
-                ],
+                    ],
+                  },
+                  "displayName": "styled.button",
+                  "render": [Function],
+                  "styledComponentId": "sc-bZQynM",
+                  "target": "button",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
               },
-              "displayName": "styled.button",
-              "render": [Function],
-              "styledComponentId": "sc-bZQynM",
-              "target": "button",
-              "toString": [Function],
-              "warnTooManyClasses": [Function],
-              "withComponent": [Function],
-            },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Next Build",
+                  "onClick": undefined,
+                },
+                "ref": null,
+                "rendered": "Next Build",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bZQynM",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    padding: 10px;
+    border: 3px solid rgba(0, 0, 0, 0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                      "#fff",
+                      ";
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.3);
+        border-color: transparent;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.button",
+                  "render": [Function],
+                  "styledComponentId": "sc-bZQynM",
+                  "target": "button",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Back to Jenkins",
+                  "href": "http://localhost:8080/job/test-pipeline/3/",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "Back to Jenkins",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bZQynM",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    padding: 10px;
+    border: 3px solid rgba(0, 0, 0, 0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                      "#fff",
+                      ";
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.3);
+        border-color: transparent;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.button",
+                  "render": [Function],
+                  "styledComponentId": "sc-bZQynM",
+                  "target": "button",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
+            ],
+            "type": "div",
           },
         ],
         "type": Object {
@@ -249,7 +362,7 @@ ShallowWrapper {
             "isStatic": true,
             "rules": Array [
               "
-    background-color:rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.2);
     padding: 10px;
     display: flex;
     align-items: center;
@@ -265,164 +378,6 @@ ShallowWrapper {
           "warnTooManyClasses": [Function],
           "withComponent": [Function],
         },
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": <ForwardRef>
-            <ForwardRef
-              href="http://2/"
-              onClick={[Function]}
-            >
-              Previous Build
-            </ForwardRef>
-            <ForwardRef
-              href="http://4/"
-              onClick={[Function]}
-            >
-              Next Build
-            </ForwardRef>
-          </ForwardRef>,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": Array [
-              <ForwardRef
-                href="http://2/"
-                onClick={[Function]}
-              >
-                Previous Build
-              </ForwardRef>,
-              <ForwardRef
-                href="http://4/"
-                onClick={[Function]}
-              >
-                Next Build
-              </ForwardRef>,
-            ],
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "children": "Previous Build",
-                "href": "http://2/",
-                "onClick": [Function],
-              },
-              "ref": null,
-              "rendered": "Previous Build",
-              "type": Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "sc-bZQynM",
-                  "isStatic": true,
-                  "rules": Array [
-                    "
-    padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
-    background-color: transparent;
-    cursor: pointer;
-    transition: 0.5s;
-    color: ",
-                    "#fff",
-                    ";
-
-    &:hover {
-        background-color: rgba(0,0,0,0.3);
-        border-color: transparent;
-    }
-",
-                  ],
-                },
-                "displayName": "styled.button",
-                "render": [Function],
-                "styledComponentId": "sc-bZQynM",
-                "target": "button",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              },
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "children": "Next Build",
-                "href": "http://4/",
-                "onClick": [Function],
-              },
-              "ref": null,
-              "rendered": "Next Build",
-              "type": Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "sc-bZQynM",
-                  "isStatic": true,
-                  "rules": Array [
-                    "
-    padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
-    background-color: transparent;
-    cursor: pointer;
-    transition: 0.5s;
-    color: ",
-                    "#fff",
-                    ";
-
-    &:hover {
-        background-color: rgba(0,0,0,0.3);
-        border-color: transparent;
-    }
-",
-                  ],
-                },
-                "displayName": "styled.button",
-                "render": [Function],
-                "styledComponentId": "sc-bZQynM",
-                "target": "button",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              },
-            },
-          ],
-          "type": Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "attrs": Array [],
-            "componentStyle": ComponentStyle {
-              "componentId": "sc-gzVnrw",
-              "isStatic": true,
-              "rules": Array [
-                "
-    background-color:rgba(0, 0, 0, 0.2);
-    display: flex;
-    justify-content: flex-start;
-    padding: 10px;
-",
-              ],
-            },
-            "displayName": "styled.div",
-            "render": [Function],
-            "styledComponentId": "sc-gzVnrw",
-            "target": "div",
-            "toString": [Function],
-            "warnTooManyClasses": [Function],
-            "withComponent": [Function],
-          },
-        },
-        "type": Symbol(react.fragment),
       },
       Object {
         "instance": null,
@@ -714,29 +669,21 @@ ShallowWrapper {
                 Build timeline &gt; #3
               </ForwardRef>
             </ForwardRef>
-            <ForwardRef
-              href="http://localhost:8080/job/test-pipeline/3/"
-              onClick={[Function]}
-            >
-              Back to Jenkins
-            </ForwardRef>
-          </ForwardRef>,
-          <React.Fragment>
-            <ForwardRef>
-              <ForwardRef
-                href="http://2/"
-                onClick={[Function]}
-              >
+            <div>
+              <ForwardRef>
                 Previous Build
               </ForwardRef>
-              <ForwardRef
-                href="http://4/"
-                onClick={[Function]}
-              >
+              <ForwardRef>
                 Next Build
               </ForwardRef>
-            </ForwardRef>
-          </React.Fragment>,
+              <ForwardRef
+                href="http://localhost:8080/job/test-pipeline/3/"
+                onClick={[Function]}
+              >
+                Back to Jenkins
+              </ForwardRef>
+            </div>
+          </ForwardRef>,
           <React.Fragment>
             <ForwardRef>
               <ForwardRef
@@ -774,12 +721,20 @@ ShallowWrapper {
                   Build timeline &gt; #3
                 </ForwardRef>
               </ForwardRef>,
-              <ForwardRef
-                href="http://localhost:8080/job/test-pipeline/3/"
-                onClick={[Function]}
-              >
-                Back to Jenkins
-              </ForwardRef>,
+              <div>
+                <ForwardRef>
+                  Previous Build
+                </ForwardRef>
+                <ForwardRef>
+                  Next Build
+                </ForwardRef>
+                <ForwardRef
+                  href="http://localhost:8080/job/test-pipeline/3/"
+                  onClick={[Function]}
+                >
+                  Back to Jenkins
+                </ForwardRef>
+              </div>,
             ],
           },
           "ref": null,
@@ -870,46 +825,157 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "function",
+              "nodeType": "host",
               "props": Object {
-                "children": "Back to Jenkins",
-                "href": "http://localhost:8080/job/test-pipeline/3/",
-                "onClick": [Function],
+                "children": Array [
+                  <ForwardRef>
+                    Previous Build
+                  </ForwardRef>,
+                  <ForwardRef>
+                    Next Build
+                  </ForwardRef>,
+                  <ForwardRef
+                    href="http://localhost:8080/job/test-pipeline/3/"
+                    onClick={[Function]}
+                  >
+                    Back to Jenkins
+                  </ForwardRef>,
+                ],
               },
               "ref": null,
-              "rendered": "Back to Jenkins",
-              "type": Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "sc-bZQynM",
-                  "isStatic": true,
-                  "rules": Array [
-                    "
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Previous Build",
+                    "onClick": undefined,
+                  },
+                  "ref": null,
+                  "rendered": "Previous Build",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bZQynM",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
     padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
+    border: 3px solid rgba(0, 0, 0, 0.3);
     background-color: transparent;
     cursor: pointer;
     transition: 0.5s;
     color: ",
-                    "#fff",
-                    ";
+                        "#fff",
+                        ";
 
     &:hover {
-        background-color: rgba(0,0,0,0.3);
+        background-color: rgba(0, 0, 0, 0.3);
         border-color: transparent;
     }
 ",
-                  ],
+                      ],
+                    },
+                    "displayName": "styled.button",
+                    "render": [Function],
+                    "styledComponentId": "sc-bZQynM",
+                    "target": "button",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
                 },
-                "displayName": "styled.button",
-                "render": [Function],
-                "styledComponentId": "sc-bZQynM",
-                "target": "button",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Next Build",
+                    "onClick": undefined,
+                  },
+                  "ref": null,
+                  "rendered": "Next Build",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bZQynM",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
+    padding: 10px;
+    border: 3px solid rgba(0, 0, 0, 0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                        "#fff",
+                        ";
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.3);
+        border-color: transparent;
+    }
+",
+                      ],
+                    },
+                    "displayName": "styled.button",
+                    "render": [Function],
+                    "styledComponentId": "sc-bZQynM",
+                    "target": "button",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Back to Jenkins",
+                    "href": "http://localhost:8080/job/test-pipeline/3/",
+                    "onClick": [Function],
+                  },
+                  "ref": null,
+                  "rendered": "Back to Jenkins",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bZQynM",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
+    padding: 10px;
+    border: 3px solid rgba(0, 0, 0, 0.3);
+    background-color: transparent;
+    cursor: pointer;
+    transition: 0.5s;
+    color: ",
+                        "#fff",
+                        ";
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.3);
+        border-color: transparent;
+    }
+",
+                      ],
+                    },
+                    "displayName": "styled.button",
+                    "render": [Function],
+                    "styledComponentId": "sc-bZQynM",
+                    "target": "button",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
+                },
+              ],
+              "type": "div",
             },
           ],
           "type": Object {
@@ -920,7 +986,7 @@ ShallowWrapper {
               "isStatic": true,
               "rules": Array [
                 "
-    background-color:rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.2);
     padding: 10px;
     display: flex;
     align-items: center;
@@ -936,164 +1002,6 @@ ShallowWrapper {
             "warnTooManyClasses": [Function],
             "withComponent": [Function],
           },
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ForwardRef>
-              <ForwardRef
-                href="http://2/"
-                onClick={[Function]}
-              >
-                Previous Build
-              </ForwardRef>
-              <ForwardRef
-                href="http://4/"
-                onClick={[Function]}
-              >
-                Next Build
-              </ForwardRef>
-            </ForwardRef>,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": Array [
-                <ForwardRef
-                  href="http://2/"
-                  onClick={[Function]}
-                >
-                  Previous Build
-                </ForwardRef>,
-                <ForwardRef
-                  href="http://4/"
-                  onClick={[Function]}
-                >
-                  Next Build
-                </ForwardRef>,
-              ],
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "children": "Previous Build",
-                  "href": "http://2/",
-                  "onClick": [Function],
-                },
-                "ref": null,
-                "rendered": "Previous Build",
-                "type": Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bZQynM",
-                    "isStatic": true,
-                    "rules": Array [
-                      "
-    padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
-    background-color: transparent;
-    cursor: pointer;
-    transition: 0.5s;
-    color: ",
-                      "#fff",
-                      ";
-
-    &:hover {
-        background-color: rgba(0,0,0,0.3);
-        border-color: transparent;
-    }
-",
-                    ],
-                  },
-                  "displayName": "styled.button",
-                  "render": [Function],
-                  "styledComponentId": "sc-bZQynM",
-                  "target": "button",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                },
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "children": "Next Build",
-                  "href": "http://4/",
-                  "onClick": [Function],
-                },
-                "ref": null,
-                "rendered": "Next Build",
-                "type": Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bZQynM",
-                    "isStatic": true,
-                    "rules": Array [
-                      "
-    padding: 10px;
-    border: 3px solid rgba(0,0,0,0.3);
-    background-color: transparent;
-    cursor: pointer;
-    transition: 0.5s;
-    color: ",
-                      "#fff",
-                      ";
-
-    &:hover {
-        background-color: rgba(0,0,0,0.3);
-        border-color: transparent;
-    }
-",
-                    ],
-                  },
-                  "displayName": "styled.button",
-                  "render": [Function],
-                  "styledComponentId": "sc-bZQynM",
-                  "target": "button",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                },
-              },
-            ],
-            "type": Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "attrs": Array [],
-              "componentStyle": ComponentStyle {
-                "componentId": "sc-gzVnrw",
-                "isStatic": true,
-                "rules": Array [
-                  "
-    background-color:rgba(0, 0, 0, 0.2);
-    display: flex;
-    justify-content: flex-start;
-    padding: 10px;
-",
-                ],
-              },
-              "displayName": "styled.div",
-              "render": [Function],
-              "styledComponentId": "sc-gzVnrw",
-              "target": "div",
-              "toString": [Function],
-              "warnTooManyClasses": [Function],
-              "withComponent": [Function],
-            },
-          },
-          "type": Symbol(react.fragment),
         },
         Object {
           "instance": null,
@@ -1391,4 +1299,4 @@ ShallowWrapper {
     },
   },
 }
-`;
+`

--- a/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
+++ b/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
@@ -4,10 +4,19 @@ exports[`DashHeader renders the component 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <DashHeader
+    buildId="3"
+    buildName="#3"
     buildStatus="NOT_AVAILABLE"
-    duration={0}
-    endTime={null}
-    startTime={null}
+    buildUrl="http://localhost:8080/job/test-pipeline/3/"
+    duration={1}
+    endTime={"2021-02-24T23:50:56.797Z"}
+    longestStage={
+      Object {
+        "duration": 15131,
+        "title": "Preparation",
+      }
+    }
+    startTime={"2021-02-24T23:50:56.796Z"}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -31,10 +40,11 @@ ShallowWrapper {
               src="logo.png"
             />
             <ForwardRef>
-              Build timeline &gt; undefined
+              Build timeline &gt; #3
             </ForwardRef>
           </ForwardRef>
           <ForwardRef
+            href="http://localhost:8080/job/test-pipeline/3/"
             onClick={[Function]}
           >
             Back to Jenkins
@@ -43,13 +53,13 @@ ShallowWrapper {
         <React.Fragment>
           <ForwardRef>
             <ForwardRef
-              href="http://NaN/"
+              href="http://2/"
               onClick={[Function]}
             >
               Previous Build
             </ForwardRef>
             <ForwardRef
-              href="http://NaN/"
+              href="http://4/"
               onClick={[Function]}
             >
               Next Build
@@ -63,8 +73,28 @@ ShallowWrapper {
             >
               Status: N/A
             </ForwardRef>
+            <ForwardRef
+              clickId="timeline start time"
+            >
+              Started on February 24th 2021, 06:50:56 pm
+            </ForwardRef>
+            <ForwardRef
+              clickId="timeline running time"
+            >
+              Ran for 2 hours
+            </ForwardRef>
           </ForwardRef>
           <ForwardRef>
+            <ForwardRef
+              clickId="timeline longest stage"
+            >
+              Longest stage: Preparation (15 seconds)
+            </ForwardRef>
+            <ForwardRef
+              clickId="timeline end time"
+            >
+              Ended on February 24th 2021, 06:50:56 pm
+            </ForwardRef>
             <ForwardRef />
           </ForwardRef>
         </React.Fragment>,
@@ -85,10 +115,11 @@ ShallowWrapper {
                 src="logo.png"
               />
               <ForwardRef>
-                Build timeline &gt; undefined
+                Build timeline &gt; #3
               </ForwardRef>
             </ForwardRef>,
             <ForwardRef
+              href="http://localhost:8080/job/test-pipeline/3/"
               onClick={[Function]}
             >
               Back to Jenkins
@@ -108,7 +139,7 @@ ShallowWrapper {
                   src="logo.png"
                 />,
                 <ForwardRef>
-                  Build timeline &gt; undefined
+                  Build timeline &gt; #3
                 </ForwardRef>,
               ],
             },
@@ -131,10 +162,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "function",
                 "props": Object {
-                  "children": "Build timeline > undefined",
+                  "children": "Build timeline > #3",
                 },
                 "ref": null,
-                "rendered": "Build timeline > undefined",
+                "rendered": "Build timeline > #3",
                 "type": Object {
                   "$$typeof": Symbol(react.forward_ref),
                   "attrs": Array [],
@@ -186,7 +217,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "children": "Back to Jenkins",
-              "href": undefined,
+              "href": "http://localhost:8080/job/test-pipeline/3/",
               "onClick": [Function],
             },
             "ref": null,
@@ -257,13 +288,13 @@ ShallowWrapper {
         "props": Object {
           "children": <ForwardRef>
             <ForwardRef
-              href="http://NaN/"
+              href="http://2/"
               onClick={[Function]}
             >
               Previous Build
             </ForwardRef>
             <ForwardRef
-              href="http://NaN/"
+              href="http://4/"
               onClick={[Function]}
             >
               Next Build
@@ -278,13 +309,13 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               <ForwardRef
-                href="http://NaN/"
+                href="http://2/"
                 onClick={[Function]}
               >
                 Previous Build
               </ForwardRef>,
               <ForwardRef
-                href="http://NaN/"
+                href="http://4/"
                 onClick={[Function]}
               >
                 Next Build
@@ -299,7 +330,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "children": "Previous Build",
-                "href": "http://NaN/",
+                "href": "http://2/",
                 "onClick": [Function],
               },
               "ref": null,
@@ -343,7 +374,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "children": "Next Build",
-                "href": "http://NaN/",
+                "href": "http://4/",
                 "onClick": [Function],
               },
               "ref": null,
@@ -420,8 +451,28 @@ ShallowWrapper {
               >
                 Status: N/A
               </ForwardRef>
+              <ForwardRef
+                clickId="timeline start time"
+              >
+                Started on February 24th 2021, 06:50:56 pm
+              </ForwardRef>
+              <ForwardRef
+                clickId="timeline running time"
+              >
+                Ran for 2 hours
+              </ForwardRef>
             </ForwardRef>,
             <ForwardRef>
+              <ForwardRef
+                clickId="timeline longest stage"
+              >
+                Longest stage: Preparation (15 seconds)
+              </ForwardRef>
+              <ForwardRef
+                clickId="timeline end time"
+              >
+                Ended on February 24th 2021, 06:50:56 pm
+              </ForwardRef>
               <ForwardRef />
             </ForwardRef>,
           ],
@@ -439,8 +490,16 @@ ShallowWrapper {
                 >
                   Status: N/A
                 </ForwardRef>,
-                null,
-                null,
+                <ForwardRef
+                  clickId="timeline start time"
+                >
+                  Started on February 24th 2021, 06:50:56 pm
+                </ForwardRef>,
+                <ForwardRef
+                  clickId="timeline running time"
+                >
+                  Ran for 2 hours
+                </ForwardRef>,
               ],
             },
             "ref": null,
@@ -489,8 +548,94 @@ ShallowWrapper {
                   "withComponent": [Function],
                 },
               },
-              null,
-              null,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Started on February 24th 2021, 06:50:56 pm",
+                  "clickId": "timeline start time",
+                },
+                "ref": null,
+                "rendered": "Started on February 24th 2021, 06:50:56 pm",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-htpNat",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.span",
+                  "render": [Function],
+                  "styledComponentId": "sc-htpNat",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Ran for 2 hours",
+                  "clickId": "timeline running time",
+                },
+                "ref": null,
+                "rendered": "Ran for 2 hours",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-htpNat",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.span",
+                  "render": [Function],
+                  "styledComponentId": "sc-htpNat",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
             ],
             "type": Object {
               "$$typeof": Symbol(react.forward_ref),
@@ -521,15 +666,109 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "children": Array [
-                null,
-                null,
+                <ForwardRef
+                  clickId="timeline longest stage"
+                >
+                  Longest stage: Preparation (15 seconds)
+                </ForwardRef>,
+                <ForwardRef
+                  clickId="timeline end time"
+                >
+                  Ended on February 24th 2021, 06:50:56 pm
+                </ForwardRef>,
                 <ForwardRef />,
               ],
             },
             "ref": null,
             "rendered": Array [
-              null,
-              null,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Longest stage: Preparation (15 seconds)",
+                  "clickId": "timeline longest stage",
+                },
+                "ref": null,
+                "rendered": "Longest stage: Preparation (15 seconds)",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-htpNat",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.span",
+                  "render": [Function],
+                  "styledComponentId": "sc-htpNat",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "Ended on February 24th 2021, 06:50:56 pm",
+                  "clickId": "timeline end time",
+                },
+                "ref": null,
+                "rendered": "Ended on February 24th 2021, 06:50:56 pm",
+                "type": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-htpNat",
+                    "isStatic": true,
+                    "rules": Array [
+                      "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                    ],
+                  },
+                  "displayName": "styled.span",
+                  "render": [Function],
+                  "styledComponentId": "sc-htpNat",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+              },
               Object {
                 "instance": null,
                 "key": undefined,
@@ -643,10 +882,11 @@ ShallowWrapper {
                 src="logo.png"
               />
               <ForwardRef>
-                Build timeline &gt; undefined
+                Build timeline &gt; #3
               </ForwardRef>
             </ForwardRef>
             <ForwardRef
+              href="http://localhost:8080/job/test-pipeline/3/"
               onClick={[Function]}
             >
               Back to Jenkins
@@ -655,13 +895,13 @@ ShallowWrapper {
           <React.Fragment>
             <ForwardRef>
               <ForwardRef
-                href="http://NaN/"
+                href="http://2/"
                 onClick={[Function]}
               >
                 Previous Build
               </ForwardRef>
               <ForwardRef
-                href="http://NaN/"
+                href="http://4/"
                 onClick={[Function]}
               >
                 Next Build
@@ -675,8 +915,28 @@ ShallowWrapper {
               >
                 Status: N/A
               </ForwardRef>
+              <ForwardRef
+                clickId="timeline start time"
+              >
+                Started on February 24th 2021, 06:50:56 pm
+              </ForwardRef>
+              <ForwardRef
+                clickId="timeline running time"
+              >
+                Ran for 2 hours
+              </ForwardRef>
             </ForwardRef>
             <ForwardRef>
+              <ForwardRef
+                clickId="timeline longest stage"
+              >
+                Longest stage: Preparation (15 seconds)
+              </ForwardRef>
+              <ForwardRef
+                clickId="timeline end time"
+              >
+                Ended on February 24th 2021, 06:50:56 pm
+              </ForwardRef>
               <ForwardRef />
             </ForwardRef>
           </React.Fragment>,
@@ -697,10 +957,11 @@ ShallowWrapper {
                   src="logo.png"
                 />
                 <ForwardRef>
-                  Build timeline &gt; undefined
+                  Build timeline &gt; #3
                 </ForwardRef>
               </ForwardRef>,
               <ForwardRef
+                href="http://localhost:8080/job/test-pipeline/3/"
                 onClick={[Function]}
               >
                 Back to Jenkins
@@ -720,7 +981,7 @@ ShallowWrapper {
                     src="logo.png"
                   />,
                   <ForwardRef>
-                    Build timeline &gt; undefined
+                    Build timeline &gt; #3
                   </ForwardRef>,
                 ],
               },
@@ -743,10 +1004,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "function",
                   "props": Object {
-                    "children": "Build timeline > undefined",
+                    "children": "Build timeline > #3",
                   },
                   "ref": null,
-                  "rendered": "Build timeline > undefined",
+                  "rendered": "Build timeline > #3",
                   "type": Object {
                     "$$typeof": Symbol(react.forward_ref),
                     "attrs": Array [],
@@ -798,7 +1059,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "children": "Back to Jenkins",
-                "href": undefined,
+                "href": "http://localhost:8080/job/test-pipeline/3/",
                 "onClick": [Function],
               },
               "ref": null,
@@ -869,13 +1130,13 @@ ShallowWrapper {
           "props": Object {
             "children": <ForwardRef>
               <ForwardRef
-                href="http://NaN/"
+                href="http://2/"
                 onClick={[Function]}
               >
                 Previous Build
               </ForwardRef>
               <ForwardRef
-                href="http://NaN/"
+                href="http://4/"
                 onClick={[Function]}
               >
                 Next Build
@@ -890,13 +1151,13 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 <ForwardRef
-                  href="http://NaN/"
+                  href="http://2/"
                   onClick={[Function]}
                 >
                   Previous Build
                 </ForwardRef>,
                 <ForwardRef
-                  href="http://NaN/"
+                  href="http://4/"
                   onClick={[Function]}
                 >
                   Next Build
@@ -911,7 +1172,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "children": "Previous Build",
-                  "href": "http://NaN/",
+                  "href": "http://2/",
                   "onClick": [Function],
                 },
                 "ref": null,
@@ -955,7 +1216,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "children": "Next Build",
-                  "href": "http://NaN/",
+                  "href": "http://4/",
                   "onClick": [Function],
                 },
                 "ref": null,
@@ -1032,8 +1293,28 @@ ShallowWrapper {
                 >
                   Status: N/A
                 </ForwardRef>
+                <ForwardRef
+                  clickId="timeline start time"
+                >
+                  Started on February 24th 2021, 06:50:56 pm
+                </ForwardRef>
+                <ForwardRef
+                  clickId="timeline running time"
+                >
+                  Ran for 2 hours
+                </ForwardRef>
               </ForwardRef>,
               <ForwardRef>
+                <ForwardRef
+                  clickId="timeline longest stage"
+                >
+                  Longest stage: Preparation (15 seconds)
+                </ForwardRef>
+                <ForwardRef
+                  clickId="timeline end time"
+                >
+                  Ended on February 24th 2021, 06:50:56 pm
+                </ForwardRef>
                 <ForwardRef />
               </ForwardRef>,
             ],
@@ -1051,8 +1332,16 @@ ShallowWrapper {
                   >
                     Status: N/A
                   </ForwardRef>,
-                  null,
-                  null,
+                  <ForwardRef
+                    clickId="timeline start time"
+                  >
+                    Started on February 24th 2021, 06:50:56 pm
+                  </ForwardRef>,
+                  <ForwardRef
+                    clickId="timeline running time"
+                  >
+                    Ran for 2 hours
+                  </ForwardRef>,
                 ],
               },
               "ref": null,
@@ -1101,8 +1390,94 @@ ShallowWrapper {
                     "withComponent": [Function],
                   },
                 },
-                null,
-                null,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Started on February 24th 2021, 06:50:56 pm",
+                    "clickId": "timeline start time",
+                  },
+                  "ref": null,
+                  "rendered": "Started on February 24th 2021, 06:50:56 pm",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-htpNat",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                      ],
+                    },
+                    "displayName": "styled.span",
+                    "render": [Function],
+                    "styledComponentId": "sc-htpNat",
+                    "target": "span",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Ran for 2 hours",
+                    "clickId": "timeline running time",
+                  },
+                  "ref": null,
+                  "rendered": "Ran for 2 hours",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-htpNat",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                      ],
+                    },
+                    "displayName": "styled.span",
+                    "render": [Function],
+                    "styledComponentId": "sc-htpNat",
+                    "target": "span",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
+                },
               ],
               "type": Object {
                 "$$typeof": Symbol(react.forward_ref),
@@ -1133,15 +1508,109 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "children": Array [
-                  null,
-                  null,
+                  <ForwardRef
+                    clickId="timeline longest stage"
+                  >
+                    Longest stage: Preparation (15 seconds)
+                  </ForwardRef>,
+                  <ForwardRef
+                    clickId="timeline end time"
+                  >
+                    Ended on February 24th 2021, 06:50:56 pm
+                  </ForwardRef>,
                   <ForwardRef />,
                 ],
               },
               "ref": null,
               "rendered": Array [
-                null,
-                null,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Longest stage: Preparation (15 seconds)",
+                    "clickId": "timeline longest stage",
+                  },
+                  "ref": null,
+                  "rendered": "Longest stage: Preparation (15 seconds)",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-htpNat",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                      ],
+                    },
+                    "displayName": "styled.span",
+                    "render": [Function],
+                    "styledComponentId": "sc-htpNat",
+                    "target": "span",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "children": "Ended on February 24th 2021, 06:50:56 pm",
+                    "clickId": "timeline end time",
+                  },
+                  "ref": null,
+                  "rendered": "Ended on February 24th 2021, 06:50:56 pm",
+                  "type": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-htpNat",
+                      "isStatic": true,
+                      "rules": Array [
+                        "
+    display: flex;
+    flex: 1 0;
+
+    justify-content: center;
+
+    &:first-child {
+        justify-content: flex-start;
+        max-width: 20%;
+    }
+
+    &:last-child {
+        justify-content: flex-end;
+        max-width: 20%;
+    }
+",
+                      ],
+                    },
+                    "displayName": "styled.span",
+                    "render": [Function],
+                    "styledComponentId": "sc-htpNat",
+                    "target": "span",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  },
+                },
                 Object {
                   "instance": null,
                   "key": undefined,

--- a/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
+++ b/webapp_src/src/components/test/__snapshots__/DashHeader.test.js.snap
@@ -8,15 +8,15 @@ ShallowWrapper {
     buildName="#3"
     buildStatus="NOT_AVAILABLE"
     buildUrl="http://localhost:8080/job/test-pipeline/3/"
-    duration={1}
-    endTime={"2021-02-24T23:50:56.797Z"}
+    duration={0}
+    endTime={null}
     longestStage={
       Object {
         "duration": 15131,
         "title": "Preparation",
       }
     }
-    startTime={"2021-02-24T23:50:56.796Z"}
+    startTime={null}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -73,27 +73,12 @@ ShallowWrapper {
             >
               Status: N/A
             </ForwardRef>
-            <ForwardRef
-              clickId="timeline start time"
-            >
-              Started on February 24th 2021, 06:50:56 pm
-            </ForwardRef>
-            <ForwardRef
-              clickId="timeline running time"
-            >
-              Ran for 2 hours
-            </ForwardRef>
           </ForwardRef>
           <ForwardRef>
             <ForwardRef
               clickId="timeline longest stage"
             >
               Longest stage: Preparation (15 seconds)
-            </ForwardRef>
-            <ForwardRef
-              clickId="timeline end time"
-            >
-              Ended on February 24th 2021, 06:50:56 pm
             </ForwardRef>
             <ForwardRef />
           </ForwardRef>
@@ -451,27 +436,12 @@ ShallowWrapper {
               >
                 Status: N/A
               </ForwardRef>
-              <ForwardRef
-                clickId="timeline start time"
-              >
-                Started on February 24th 2021, 06:50:56 pm
-              </ForwardRef>
-              <ForwardRef
-                clickId="timeline running time"
-              >
-                Ran for 2 hours
-              </ForwardRef>
             </ForwardRef>,
             <ForwardRef>
               <ForwardRef
                 clickId="timeline longest stage"
               >
                 Longest stage: Preparation (15 seconds)
-              </ForwardRef>
-              <ForwardRef
-                clickId="timeline end time"
-              >
-                Ended on February 24th 2021, 06:50:56 pm
               </ForwardRef>
               <ForwardRef />
             </ForwardRef>,
@@ -490,16 +460,8 @@ ShallowWrapper {
                 >
                   Status: N/A
                 </ForwardRef>,
-                <ForwardRef
-                  clickId="timeline start time"
-                >
-                  Started on February 24th 2021, 06:50:56 pm
-                </ForwardRef>,
-                <ForwardRef
-                  clickId="timeline running time"
-                >
-                  Ran for 2 hours
-                </ForwardRef>,
+                null,
+                null,
               ],
             },
             "ref": null,
@@ -548,94 +510,8 @@ ShallowWrapper {
                   "withComponent": [Function],
                 },
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "children": "Started on February 24th 2021, 06:50:56 pm",
-                  "clickId": "timeline start time",
-                },
-                "ref": null,
-                "rendered": "Started on February 24th 2021, 06:50:56 pm",
-                "type": Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-htpNat",
-                    "isStatic": true,
-                    "rules": Array [
-                      "
-    display: flex;
-    flex: 1 0;
-
-    justify-content: center;
-
-    &:first-child {
-        justify-content: flex-start;
-        max-width: 20%;
-    }
-
-    &:last-child {
-        justify-content: flex-end;
-        max-width: 20%;
-    }
-",
-                    ],
-                  },
-                  "displayName": "styled.span",
-                  "render": [Function],
-                  "styledComponentId": "sc-htpNat",
-                  "target": "span",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                },
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "children": "Ran for 2 hours",
-                  "clickId": "timeline running time",
-                },
-                "ref": null,
-                "rendered": "Ran for 2 hours",
-                "type": Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-htpNat",
-                    "isStatic": true,
-                    "rules": Array [
-                      "
-    display: flex;
-    flex: 1 0;
-
-    justify-content: center;
-
-    &:first-child {
-        justify-content: flex-start;
-        max-width: 20%;
-    }
-
-    &:last-child {
-        justify-content: flex-end;
-        max-width: 20%;
-    }
-",
-                    ],
-                  },
-                  "displayName": "styled.span",
-                  "render": [Function],
-                  "styledComponentId": "sc-htpNat",
-                  "target": "span",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                },
-              },
+              null,
+              null,
             ],
             "type": Object {
               "$$typeof": Symbol(react.forward_ref),
@@ -671,11 +547,7 @@ ShallowWrapper {
                 >
                   Longest stage: Preparation (15 seconds)
                 </ForwardRef>,
-                <ForwardRef
-                  clickId="timeline end time"
-                >
-                  Ended on February 24th 2021, 06:50:56 pm
-                </ForwardRef>,
+                null,
                 <ForwardRef />,
               ],
             },
@@ -725,50 +597,7 @@ ShallowWrapper {
                   "withComponent": [Function],
                 },
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "children": "Ended on February 24th 2021, 06:50:56 pm",
-                  "clickId": "timeline end time",
-                },
-                "ref": null,
-                "rendered": "Ended on February 24th 2021, 06:50:56 pm",
-                "type": Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-htpNat",
-                    "isStatic": true,
-                    "rules": Array [
-                      "
-    display: flex;
-    flex: 1 0;
-
-    justify-content: center;
-
-    &:first-child {
-        justify-content: flex-start;
-        max-width: 20%;
-    }
-
-    &:last-child {
-        justify-content: flex-end;
-        max-width: 20%;
-    }
-",
-                    ],
-                  },
-                  "displayName": "styled.span",
-                  "render": [Function],
-                  "styledComponentId": "sc-htpNat",
-                  "target": "span",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                },
-              },
+              null,
               Object {
                 "instance": null,
                 "key": undefined,
@@ -915,27 +744,12 @@ ShallowWrapper {
               >
                 Status: N/A
               </ForwardRef>
-              <ForwardRef
-                clickId="timeline start time"
-              >
-                Started on February 24th 2021, 06:50:56 pm
-              </ForwardRef>
-              <ForwardRef
-                clickId="timeline running time"
-              >
-                Ran for 2 hours
-              </ForwardRef>
             </ForwardRef>
             <ForwardRef>
               <ForwardRef
                 clickId="timeline longest stage"
               >
                 Longest stage: Preparation (15 seconds)
-              </ForwardRef>
-              <ForwardRef
-                clickId="timeline end time"
-              >
-                Ended on February 24th 2021, 06:50:56 pm
               </ForwardRef>
               <ForwardRef />
             </ForwardRef>
@@ -1293,27 +1107,12 @@ ShallowWrapper {
                 >
                   Status: N/A
                 </ForwardRef>
-                <ForwardRef
-                  clickId="timeline start time"
-                >
-                  Started on February 24th 2021, 06:50:56 pm
-                </ForwardRef>
-                <ForwardRef
-                  clickId="timeline running time"
-                >
-                  Ran for 2 hours
-                </ForwardRef>
               </ForwardRef>,
               <ForwardRef>
                 <ForwardRef
                   clickId="timeline longest stage"
                 >
                   Longest stage: Preparation (15 seconds)
-                </ForwardRef>
-                <ForwardRef
-                  clickId="timeline end time"
-                >
-                  Ended on February 24th 2021, 06:50:56 pm
                 </ForwardRef>
                 <ForwardRef />
               </ForwardRef>,
@@ -1332,16 +1131,8 @@ ShallowWrapper {
                   >
                     Status: N/A
                   </ForwardRef>,
-                  <ForwardRef
-                    clickId="timeline start time"
-                  >
-                    Started on February 24th 2021, 06:50:56 pm
-                  </ForwardRef>,
-                  <ForwardRef
-                    clickId="timeline running time"
-                  >
-                    Ran for 2 hours
-                  </ForwardRef>,
+                  null,
+                  null,
                 ],
               },
               "ref": null,
@@ -1390,94 +1181,8 @@ ShallowWrapper {
                     "withComponent": [Function],
                   },
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "children": "Started on February 24th 2021, 06:50:56 pm",
-                    "clickId": "timeline start time",
-                  },
-                  "ref": null,
-                  "rendered": "Started on February 24th 2021, 06:50:56 pm",
-                  "type": Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": Array [],
-                    "componentStyle": ComponentStyle {
-                      "componentId": "sc-htpNat",
-                      "isStatic": true,
-                      "rules": Array [
-                        "
-    display: flex;
-    flex: 1 0;
-
-    justify-content: center;
-
-    &:first-child {
-        justify-content: flex-start;
-        max-width: 20%;
-    }
-
-    &:last-child {
-        justify-content: flex-end;
-        max-width: 20%;
-    }
-",
-                      ],
-                    },
-                    "displayName": "styled.span",
-                    "render": [Function],
-                    "styledComponentId": "sc-htpNat",
-                    "target": "span",
-                    "toString": [Function],
-                    "warnTooManyClasses": [Function],
-                    "withComponent": [Function],
-                  },
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "children": "Ran for 2 hours",
-                    "clickId": "timeline running time",
-                  },
-                  "ref": null,
-                  "rendered": "Ran for 2 hours",
-                  "type": Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": Array [],
-                    "componentStyle": ComponentStyle {
-                      "componentId": "sc-htpNat",
-                      "isStatic": true,
-                      "rules": Array [
-                        "
-    display: flex;
-    flex: 1 0;
-
-    justify-content: center;
-
-    &:first-child {
-        justify-content: flex-start;
-        max-width: 20%;
-    }
-
-    &:last-child {
-        justify-content: flex-end;
-        max-width: 20%;
-    }
-",
-                      ],
-                    },
-                    "displayName": "styled.span",
-                    "render": [Function],
-                    "styledComponentId": "sc-htpNat",
-                    "target": "span",
-                    "toString": [Function],
-                    "warnTooManyClasses": [Function],
-                    "withComponent": [Function],
-                  },
-                },
+                null,
+                null,
               ],
               "type": Object {
                 "$$typeof": Symbol(react.forward_ref),
@@ -1513,11 +1218,7 @@ ShallowWrapper {
                   >
                     Longest stage: Preparation (15 seconds)
                   </ForwardRef>,
-                  <ForwardRef
-                    clickId="timeline end time"
-                  >
-                    Ended on February 24th 2021, 06:50:56 pm
-                  </ForwardRef>,
+                  null,
                   <ForwardRef />,
                 ],
               },
@@ -1567,50 +1268,7 @@ ShallowWrapper {
                     "withComponent": [Function],
                   },
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "children": "Ended on February 24th 2021, 06:50:56 pm",
-                    "clickId": "timeline end time",
-                  },
-                  "ref": null,
-                  "rendered": "Ended on February 24th 2021, 06:50:56 pm",
-                  "type": Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": Array [],
-                    "componentStyle": ComponentStyle {
-                      "componentId": "sc-htpNat",
-                      "isStatic": true,
-                      "rules": Array [
-                        "
-    display: flex;
-    flex: 1 0;
-
-    justify-content: center;
-
-    &:first-child {
-        justify-content: flex-start;
-        max-width: 20%;
-    }
-
-    &:last-child {
-        justify-content: flex-end;
-        max-width: 20%;
-    }
-",
-                      ],
-                    },
-                    "displayName": "styled.span",
-                    "render": [Function],
-                    "styledComponentId": "sc-htpNat",
-                    "target": "span",
-                    "toString": [Function],
-                    "warnTooManyClasses": [Function],
-                    "withComponent": [Function],
-                  },
-                },
+                null,
                 Object {
                   "instance": null,
                   "key": undefined,

--- a/webapp_src/src/components/test/mockData.js
+++ b/webapp_src/src/components/test/mockData.js
@@ -107,3 +107,18 @@ export const mockNodeApiResponse = {
         ],
     },
 }
+
+export const mockJobWfApiResponse = {
+    data: {
+        _links: {
+            self: {
+                href: '/job/test/wfapi/describe',
+            },
+            runs: {
+                href: '/job/test/wfapi/runs',
+            },
+        },
+        name: 'test',
+        runCount: 3,
+    },
+}


### PR DESCRIPTION
Demo

https://user-images.githubusercontent.com/25181701/110224560-b91a9800-7eaa-11eb-9cac-2a28d26423bc.mp4



## Description
<!-- Add a bulleted list of items changed or added -->
resolves #116 Issue

Adding a simple previous and next build button to quickly navigate between builds of the same pipeline.

Note: this isn't aware of the max build number, so if you click on "next build" on the most recent build, it'd take you to a blank page.

## DevQA
:white_check_mark: created a pipeline with 3 builds, see that on first build, "previous build" button isn't rendered, and is able to navigate to the next build.

:white_check_mark: from build 2, able to go back to first build, or to next build. 

:white_check_mark: From build 3, see that next build button is not rendered because it's the last build in the job.

### DevQA Prep
<!-- Delete items that do not apply. -->
- run "make build_and_export", then add the plugin into local jenkins build

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->



### Comments:
<!-- Any other comments you want to include for reviewers. -->


